### PR TITLE
feat(search): filter searchHistory as the user types

### DIFF
--- a/lib/screens/search/search.dart
+++ b/lib/screens/search/search.dart
@@ -25,6 +25,7 @@ class Search extends HookConsumerWidget {
 
     // State
     final isLoading = useState(false);
+    final searchValue = useState("");
 
     // Methods
     final navigateToPlayerDetail = useCallback(
@@ -48,6 +49,13 @@ class Search extends HookConsumerWidget {
           text: "Player $playerName not found",
           type: widgets.ToastType.info,
         );
+      },
+      [],
+    );
+
+    final onChangeText = useCallback(
+      (String value) {
+        searchValue.value = value.toLowerCase();
       },
       [],
     );
@@ -92,10 +100,16 @@ class Search extends HookConsumerWidget {
 
     return CustomScrollView(
       slivers: [
-        SearchAppBar(isLoading: isLoading.value, onSearch: onSearch),
+        SearchAppBar(
+          isLoading: isLoading.value,
+          onSearch: onSearch,
+          onChangeText: onChangeText,
+        ),
         topSearchList.isNotEmpty
             ? const SearchTopList()
-            : const SearchHistory(),
+            : SearchHistory(
+                searchValue: searchValue.value,
+              ),
         if (lowerSearchList.isNotEmpty) const SearchLowerList(),
       ],
     );

--- a/lib/screens/search/search_app_bar.dart
+++ b/lib/screens/search/search_app_bar.dart
@@ -8,10 +8,12 @@ import "package:paladinsedge/providers/index.dart" as providers;
 class SearchAppBar extends HookConsumerWidget {
   final bool isLoading;
   final void Function(String) onSearch;
+  final void Function(String) onChangeText;
 
   const SearchAppBar({
     required this.isLoading,
     required this.onSearch,
+    required this.onChangeText,
     Key? key,
   }) : super(key: key);
 
@@ -33,6 +35,7 @@ class SearchAppBar extends HookConsumerWidget {
       () {
         searchProvider.clearSearchList();
         textController.clear();
+        onChangeText("");
       },
       [],
     );
@@ -46,6 +49,7 @@ class SearchAppBar extends HookConsumerWidget {
         controller: textController,
         maxLength: 30,
         style: textStyle,
+        onChanged: onChangeText,
         onSubmitted: isLoading ? null : onSearch,
         decoration: InputDecoration(
           hintText: "Search player",

--- a/lib/screens/search/search_history.dart
+++ b/lib/screens/search/search_history.dart
@@ -9,7 +9,11 @@ import "package:paladinsedge/utilities/index.dart" as utilities;
 import "package:timer_builder/timer_builder.dart";
 
 class SearchHistory extends HookConsumerWidget {
-  const SearchHistory({Key? key}) : super(key: key);
+  final String searchValue;
+  const SearchHistory({
+    required this.searchValue,
+    Key? key,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -20,6 +24,16 @@ class SearchHistory extends HookConsumerWidget {
 
     // Variables
     final textTheme = Theme.of(context).textTheme;
+
+    // Hooks
+    final filteredSearchHistory = useMemoized(
+      () {
+        return searchHistory.where(
+          (_) => _.playerName.toLowerCase().contains(searchValue),
+        );
+      },
+      [searchValue, searchHistory],
+    );
 
     // Methods
     final onTap = useCallback(
@@ -42,7 +56,7 @@ class SearchHistory extends HookConsumerWidget {
     return SliverList(
       delegate: SliverChildBuilderDelegate(
         (context, index) {
-          final search = searchHistory[index];
+          final search = filteredSearchHistory.elementAt(index);
 
           return ListTile(
             onTap: () => onTap(search.playerId),
@@ -61,7 +75,7 @@ class SearchHistory extends HookConsumerWidget {
             ),
           );
         },
-        childCount: searchHistory.length,
+        childCount: filteredSearchHistory.length,
       ),
     );
   }


### PR DESCRIPTION
searchHistory is filterd out as the user types in the search bar

resolves #381

<!-- Please refer to our contributing documentation : https://github.com/tusharlock10/paladins-edge-client/tree/main/.github/contributing.md -->

<!-- It is important that you create an issue before raising a PR. Link this PR to that issue : https://github.com/tusharlock10/paladins-edge-client/issues -->

## **PR Checklist**

Please check if your PR fulfills the following requirements:
- [x] App has been built and tested (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR is linked to the *GitHub* issue that is being addressed
- [x] Appropriate labels have been added to the PR

## Type of PR

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Build/ Workflow
- [ ] Documentation
- [ ] Other 


## Issue resolution

<!-- Please describe the how this PR is going to resolve the issue -->

Tell us about how the fix/ feature resolves the linked issue

- Filter search history on typing

## Breaking change

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

If this is a breaking change (i.e. removing a feature, etc.) that could impact existing users

- [ ] Yes
- [x] No