### PR TITLE
feat(queueregion): add queueRegion selection option in home queue charts

### DIFF
--- a/lib/constants/database.dart
+++ b/lib/constants/database.dart
@@ -66,6 +66,7 @@ abstract class TypeIds {
   static const bountyStore = 13;
   static const queue = 14;
   static const item = 15;
+  static const queueRegion = 16;
 }
 
 abstract class StorageKeys {

--- a/lib/data_classes/common/index.dart
+++ b/lib/data_classes/common/index.dart
@@ -1,1 +1,2 @@
 export "./common.dart";
+export "./region.dart";

--- a/lib/data_classes/common/region.dart
+++ b/lib/data_classes/common/region.dart
@@ -1,0 +1,53 @@
+import "package:dartx/dartx.dart";
+
+abstract class Region {
+  static const northAmerica = "NA";
+  static const europe = "EU";
+  static const brazil = "BR";
+  static const japan = "JP";
+  static const southEastAsia = "SEA";
+  static const latinAmerica = "LA";
+  static const oceania = "OCE";
+  static const all = "ALL";
+
+  static const defaultRegion = all;
+
+  static const allRegions = [
+    northAmerica,
+    europe,
+    brazil,
+    japan,
+    southEastAsia,
+    latinAmerica,
+    oceania,
+    all,
+  ];
+
+  static String getFullName(String region) {
+    switch (region) {
+      case northAmerica:
+        return "North America";
+      case europe:
+        return "Europe";
+      case brazil:
+        return "Brazil";
+      case japan:
+        return "Japan";
+      case southEastAsia:
+        return "South East Asia";
+      case latinAmerica:
+        return "Latin America";
+      case oceania:
+        return "Oceania";
+    }
+
+    return "All Regions";
+  }
+
+  /// Get the next region in line when a region is provided
+  static String cycleRegions(String region) {
+    final index = allRegions.indexWhere((queueRegion) => queueRegion == region);
+
+    return allRegions.elementAtOrDefault(index + 1, allRegions.first);
+  }
+}

--- a/lib/models/queue/queue.dart
+++ b/lib/models/queue/queue.dart
@@ -4,6 +4,27 @@ import "package:paladinsedge/constants/index.dart" show TypeIds;
 
 part "queue.g.dart";
 
+@HiveType(typeId: TypeIds.queueRegion)
+@JsonSerializable()
+class QueueRegion {
+  /// region of the matches
+  @HiveField(0)
+  final String region;
+
+  /// Number of matches being played currently in this region
+  @HiveField(1)
+  final int activeMatchCount;
+
+  QueueRegion({
+    required this.region,
+    required this.activeMatchCount,
+  });
+
+  factory QueueRegion.fromJson(Map<String, dynamic> json) =>
+      _$QueueRegionFromJson(json);
+  Map<String, dynamic> toJson() => _$QueueRegionToJson(this);
+}
+
 @HiveType(typeId: TypeIds.queue)
 @JsonSerializable()
 class Queue {
@@ -23,11 +44,16 @@ class Queue {
   @HiveField(3)
   final DateTime createdAt;
 
+  /// A breakup of the matches by region
+  @HiveField(4, defaultValue: [])
+  final List<QueueRegion> queueRegions;
+
   Queue({
     required this.queueId,
     required this.name,
     required this.activeMatchCount,
     required this.createdAt,
+    required this.queueRegions,
   });
 
   factory Queue.fromJson(Map<String, dynamic> json) => _$QueueFromJson(json);

--- a/lib/models/queue/queue.g.dart
+++ b/lib/models/queue/queue.g.dart
@@ -6,6 +6,43 @@ part of 'queue.dart';
 // TypeAdapterGenerator
 // **************************************************************************
 
+class QueueRegionAdapter extends TypeAdapter<QueueRegion> {
+  @override
+  final int typeId = 16;
+
+  @override
+  QueueRegion read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return QueueRegion(
+      region: fields[0] as String,
+      activeMatchCount: fields[1] as int,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, QueueRegion obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.region)
+      ..writeByte(1)
+      ..write(obj.activeMatchCount);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is QueueRegionAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
 class QueueAdapter extends TypeAdapter<Queue> {
   @override
   final int typeId = 14;
@@ -21,13 +58,15 @@ class QueueAdapter extends TypeAdapter<Queue> {
       name: fields[1] as String,
       activeMatchCount: fields[2] as int,
       createdAt: fields[3] as DateTime,
+      queueRegions:
+          fields[4] == null ? [] : (fields[4] as List).cast<QueueRegion>(),
     );
   }
 
   @override
   void write(BinaryWriter writer, Queue obj) {
     writer
-      ..writeByte(4)
+      ..writeByte(5)
       ..writeByte(0)
       ..write(obj.queueId)
       ..writeByte(1)
@@ -35,7 +74,9 @@ class QueueAdapter extends TypeAdapter<Queue> {
       ..writeByte(2)
       ..write(obj.activeMatchCount)
       ..writeByte(3)
-      ..write(obj.createdAt);
+      ..write(obj.createdAt)
+      ..writeByte(4)
+      ..write(obj.queueRegions);
   }
 
   @override
@@ -53,11 +94,25 @@ class QueueAdapter extends TypeAdapter<Queue> {
 // JsonSerializableGenerator
 // **************************************************************************
 
+QueueRegion _$QueueRegionFromJson(Map<String, dynamic> json) => QueueRegion(
+      region: json['region'] as String,
+      activeMatchCount: json['activeMatchCount'] as int,
+    );
+
+Map<String, dynamic> _$QueueRegionToJson(QueueRegion instance) =>
+    <String, dynamic>{
+      'region': instance.region,
+      'activeMatchCount': instance.activeMatchCount,
+    };
+
 Queue _$QueueFromJson(Map<String, dynamic> json) => Queue(
       queueId: json['queueId'] as int,
       name: json['name'] as String,
       activeMatchCount: json['activeMatchCount'] as int,
       createdAt: DateTime.parse(json['createdAt'] as String),
+      queueRegions: (json['queueRegions'] as List<dynamic>)
+          .map((e) => QueueRegion.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
 Map<String, dynamic> _$QueueToJson(Queue instance) => <String, dynamic>{
@@ -65,4 +120,5 @@ Map<String, dynamic> _$QueueToJson(Queue instance) => <String, dynamic>{
       'name': instance.name,
       'activeMatchCount': instance.activeMatchCount,
       'createdAt': instance.createdAt.toIso8601String(),
+      'queueRegions': instance.queueRegions,
     };

--- a/lib/models/settings/settings.dart
+++ b/lib/models/settings/settings.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:hive/hive.dart";
 import "package:paladinsedge/constants/index.dart" show TypeIds;
+import "package:paladinsedge/data_classes/common/region.dart" show Region;
 
 part "settings.g.dart";
 
@@ -11,6 +12,10 @@ class Settings extends HiveObject {
   /// in commonMatches
   @HiveField(1, defaultValue: false)
   bool showUserPlayerMatches = false;
+
+  /// Used to store the value of selected queue by user in db
+  @HiveField(2, defaultValue: Region.all)
+  String selectedQueueRegion = Region.all;
 
   // initialize _themeMode to the system theme
   /// 0 means theme is system based, 1 means light theme, 2 means dark theme

--- a/lib/models/settings/settings.g.dart
+++ b/lib/models/settings/settings.g.dart
@@ -18,15 +18,18 @@ class SettingsAdapter extends TypeAdapter<Settings> {
     };
     return Settings()
       ..showUserPlayerMatches = fields[1] == null ? false : fields[1] as bool
+      ..selectedQueueRegion = fields[2] == null ? 'ALL' : fields[2] as String
       .._themeMode = fields[0] as int;
   }
 
   @override
   void write(BinaryWriter writer, Settings obj) {
     writer
-      ..writeByte(2)
+      ..writeByte(3)
       ..writeByte(1)
       ..write(obj.showUserPlayerMatches)
+      ..writeByte(2)
+      ..write(obj.selectedQueueRegion)
       ..writeByte(0)
       ..write(obj._themeMode);
   }

--- a/lib/providers/auth.dart
+++ b/lib/providers/auth.dart
@@ -335,8 +335,8 @@ class _AuthNotifier extends ChangeNotifier {
       user!.favouriteFriends = response.favouriteFriends;
     }
 
-    utilities.Database.saveUser(user!);
     notifyListeners();
+    utilities.Database.saveUser(user!);
 
     return result;
   }
@@ -409,8 +409,8 @@ class _AuthNotifier extends ChangeNotifier {
       user!.savedMatches = response.savedMatches;
     }
 
-    utilities.Database.saveUser(user!);
     notifyListeners();
+    utilities.Database.saveUser(user!);
 
     return result;
   }
@@ -466,19 +466,26 @@ class _AuthNotifier extends ChangeNotifier {
     } else if (themeMode == ThemeMode.system) {
       themeName = "system";
     }
+    notifyListeners();
     utilities.Analytics.logEvent(
       constants.AnalyticsEvent.changeTheme,
       {"theme": themeName},
     );
     utilities.Database.saveSettings(settings);
-    notifyListeners();
   }
 
   /// Toggle showUserPlayerMatches for commonMatches
   void toggleShowUserPlayerMatches(bool? value) {
     settings.showUserPlayerMatches = value ?? false;
-    utilities.Database.saveSettings(settings);
     notifyListeners();
+    utilities.Database.saveSettings(settings);
+  }
+
+  /// Set queue region in settings
+  void setQueueRegions(String region) {
+    settings.selectedQueueRegion = region;
+    notifyListeners();
+    utilities.Database.saveSettings(settings);
   }
 
   void clearData() {

--- a/lib/screens/home/home_queue_details.dart
+++ b/lib/screens/home/home_queue_details.dart
@@ -3,6 +3,7 @@ import "package:flutter_hooks/flutter_hooks.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:paladinsedge/providers/index.dart" as providers;
 import "package:paladinsedge/screens/home/home_queue_card.dart";
+import "package:paladinsedge/screens/home/home_queue_region_card.dart";
 import "package:paladinsedge/utilities/index.dart" as utilities;
 import "package:paladinsedge/widgets/index.dart" as widgets;
 
@@ -14,8 +15,9 @@ class HomeQueueDetails extends HookConsumerWidget {
     // Providers
     final queueProvider = ref.read(providers.queue);
     final queue = ref.watch(providers.queue.select((_) => _.queue));
-    final selectedQueueId =
-        ref.watch(providers.queue.select((_) => _.selectedQueueId));
+    final selectedQueueId = ref.watch(
+      providers.queue.select((_) => _.selectedQueueId),
+    );
     final isLoading = ref.watch(providers.queue.select((_) => _.isLoading));
 
     // Variables
@@ -84,16 +86,16 @@ class HomeQueueDetails extends HookConsumerWidget {
                           horizontal: 20,
                           vertical: 15,
                         ),
-                        children: queue
-                            .where((queue) => queue.queueId != 0)
-                            .map(
-                              (queue) => HomeQueueCard(
-                                queue: queue,
-                                isSelected: selectedQueueId == queue.queueId,
-                                onTap: getQueueTimeline,
+                        children: [
+                          const HomeQueueRegionCard(),
+                          ...queue.where((queue) => queue.queueId != 0).map(
+                                (queue) => HomeQueueCard(
+                                  queue: queue,
+                                  isSelected: selectedQueueId == queue.queueId,
+                                  onTap: getQueueTimeline,
+                                ),
                               ),
-                            )
-                            .toList(),
+                        ],
                       ),
               ],
             ),

--- a/lib/screens/home/home_queue_region_card.dart
+++ b/lib/screens/home/home_queue_region_card.dart
@@ -1,0 +1,64 @@
+import "package:flutter/material.dart";
+import "package:flutter_hooks/flutter_hooks.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:paladinsedge/data_classes/index.dart" as data_classes;
+import "package:paladinsedge/providers/index.dart" as providers;
+import "package:paladinsedge/widgets/index.dart" as widgets;
+
+class HomeQueueRegionCard extends HookConsumerWidget {
+  const HomeQueueRegionCard({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Providers
+    final authProvider = ref.read(providers.auth);
+    final queueProvider = ref.read(providers.queue);
+    final selectedQueueRegion = ref.watch(
+      providers.auth.select((_) => _.settings.selectedQueueRegion),
+    );
+    final selectedQueueId = ref.watch(
+      providers.queue.select((_) => _.selectedQueueId),
+    );
+
+    // Variables
+    final textTheme = Theme.of(context).textTheme;
+
+    // Hooks
+    final regionFullName = useMemoized(
+      () => data_classes.Region.getFullName(selectedQueueRegion),
+      [selectedQueueRegion],
+    );
+
+    // Methods
+    final onTap = useCallback(
+      () {
+        final nextRegion =
+            data_classes.Region.cycleRegions(selectedQueueRegion);
+        authProvider.setQueueRegions(nextRegion);
+        queueProvider.selectTimelineQueue(selectedQueueId);
+      },
+      [selectedQueueRegion, selectedQueueRegion],
+    );
+
+    return widgets.InteractiveCard(
+      elevation: 2,
+      borderRadius: 10,
+      onTap: onTap,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            "Select Region",
+            textAlign: TextAlign.center,
+            style: textTheme.bodyText1,
+          ),
+          const SizedBox(height: 5),
+          Text(
+            regionFullName,
+            style: textTheme.bodyText2?.copyWith(fontSize: 16),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/utilities/region.dart
+++ b/lib/utilities/region.dart
@@ -1,0 +1,24 @@
+import "package:paladinsedge/data_classes/index.dart" as data_classes;
+
+/// Takes a region in a random string format and provides the appropriate formatted region
+String? sanitizeRegion(String region) {
+  region = region.toLowerCase();
+
+  if (region.contains("eu")) return data_classes.Region.europe;
+  if (region.contains("sea") || region.contains("asia")) {
+    return data_classes.Region.southEastAsia;
+  }
+  if (region.contains("br")) return data_classes.Region.brazil;
+  if (region.contains("aus") || region.contains("oce")) {
+    return data_classes.Region.oceania;
+  }
+  if (region.contains("latin")) return data_classes.Region.latinAmerica;
+  if (region.contains("jp") || region.contains("japan")) {
+    return data_classes.Region.japan;
+  }
+  if (region.contains("na") || region.contains("north")) {
+    return data_classes.Region.northAmerica;
+  }
+
+  return null;
+}


### PR DESCRIPTION
added button to toggle queue based on region in home queue chart

resolves #399

<!-- Please refer to our contributing documentation : https://github.com/tusharlock10/paladins-edge-client/tree/main/.github/contributing.md -->

<!-- It is important that you create an issue before raising a PR. Link this PR to that issue : https://github.com/tusharlock10/paladins-edge-client/issues -->

## **PR Checklist**

Please check if your PR fulfills the following requirements:
- [x] App has been built and tested (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR is linked to the *GitHub* issue that is being addressed
- [x] Appropriate labels have been added to the PR

## Type of PR

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Build/ Workflow
- [ ] Documentation
- [ ] Other 


## Issue resolution

<!-- Please describe the how this PR is going to resolve the issue -->

Tell us about how the fix/ feature resolves the linked issue

- Add queue region selection in home queue chart

## Breaking change

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

If this is a breaking change (i.e. removing a feature, etc.) that could impact existing users

- [ ] Yes
- [x] No